### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 A self-diagnostic framework for AI models that enables them to diagnose and fix MCP-related issues.
 
+<a href="https://glama.ai/mcp/servers/@devlimelabs/mcp-troubleshooter-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@devlimelabs/mcp-troubleshooter-mcp/badge" alt="Troubleshooter MCP server" />
+</a>
+
 ## Architecture
 
 ```mermaid


### PR DESCRIPTION
This PR adds a badge for the [MCP Troubleshooter](https://glama.ai/mcp/servers/@devlimelabs/mcp-troubleshooter-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@devlimelabs/mcp-troubleshooter-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@devlimelabs/mcp-troubleshooter-mcp/badge" alt="Troubleshooter MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.